### PR TITLE
Supported more bib styles and shorted doi URLs too

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ for line in fileinput.input():
 
         if doi:
             data = json.load(request.urlopen("http://shortdoi.org/%s?format=json" % doi))
-            print(line.replace(doi, data["ShortDOI"]), end="")
+            print(line.replace(doi, data["ShortDOI"][3 * bool(search_url):]), end="")
         else:
             print(line, end="")
     except Exception as err:

--- a/main.py
+++ b/main.py
@@ -10,8 +10,8 @@ regex_url = r"url\s?=\s?[{\"'](https?://doi\.org/([\w\.]+/[^}/\"']+))/?[}\"']"
 
 for line in fileinput.input():
     try:
-        search_doi = re.search(regex_doi, re.sub("\s+", "", line).lower(), re.IGNORECASE)
-        search_url = re.search(regex_url, re.sub("\s+", "", line).lower(), re.IGNORECASE)
+        search_doi = re.search(regex_doi, re.sub("\s+", "", line), re.IGNORECASE)
+        search_url = re.search(regex_url, re.sub("\s+", "", line), re.IGNORECASE)
         doi = (
             (search_doi and search_doi.group(1)) or
             (search_url and search_url.group(2))

--- a/main.py
+++ b/main.py
@@ -18,8 +18,9 @@ for line in fileinput.input():
         )
 
         if doi:
+            short_doi = data["shortDOI"][3:] if search_url else data["shortDOI"]
             data = json.load(request.urlopen("http://shortdoi.org/%s?format=json" % doi))
-            print(line.replace(doi, data["ShortDOI"][3 * bool(search_url):]), end="")
+            print(line.replace(doi, short_doi, end="")
         else:
             print(line, end="")
     except Exception as err:

--- a/main.py
+++ b/main.py
@@ -4,11 +4,20 @@ import re
 import urllib.request as request
 import sys
 
+regex_doi = r"doi\s?=\s?[{\"']([^}\"']+)[}\"']"
+regex_url = r"url\s?=\s?[{\"'](https?://doi\.org/([\w\.]+/[^}/\"']+))/?[}\"']"
+
 
 for line in fileinput.input():
     try:
-        if "doi={" in re.sub("\s+", "", line).lower():
-            doi = re.search("{(.+)}", line).group(1)
+        search_doi = re.search(regex_doi, re.sub("\s+", "", line).lower(), re.IGNORECASE)
+        search_url = re.search(regex_url, re.sub("\s+", "", line).lower(), re.IGNORECASE)
+        doi = (
+            (search_doi and search_doi.group(1)) or
+            (search_url and search_url.group(2))
+        )
+
+        if doi:
             data = json.load(request.urlopen("http://shortdoi.org/%s?format=json" % doi))
             print(line.replace(doi, data["ShortDOI"]), end="")
         else:


### PR DESCRIPTION
The following lines :

```
doi={10.1016/j.eatbeh.2013.01.011},
doi = {10.1016/j.eatbeh.2013.01.011},
doi="10.1016/j.eatbeh.2013.01.011",
doi='10.1016/j.eatbeh.2013.01.011',
url={https://doi.org/10.1136/bmj.g7092}
url = {https://doi.org/10.1136/bmj.g7092}
url="https://doi.org/10.1136/bmj.g7092"
url='https://doi.org/10.1136/bmj.g7092'
```

should now be shortified too:

```
doi={10/f4r645},
doi = {10/f4r645},
doi="10/f4r645",
doi='10/f4r645',
url={https://doi.org/f6xchr}
url = {https://doi.org/f6xchr}
url="https://doi.org/f6xchr"
url='https://doi.org/f6xchr'
```

Both papers are highly recommended for reading!